### PR TITLE
Equation typo in exercise a)

### DIFF
--- a/doc/Projects/2020/Project1/pdf/Project1.tex
+++ b/doc/Projects/2020/Project1/pdf/Project1.tex
@@ -321,7 +321,7 @@ where we have defined $r_{ij}=|\mathbf{r}_i-\mathbf{r}_j|$
 and
 
 \begin{equation*}
-   f(r_{ij})= \exp{\left(\sum_{i<j}u(r_{ij})\right)},
+   \prod_{i<j} f(r_{ij})= \exp{\left(\sum_{i<j}u(r_{ij})\right)},
 \end{equation*}
 with $u(r_{ij})=\ln{f(r_{ij})}$.
 We have also


### PR DESCRIPTION
Missing a product sign before f(r_{ij}) in an equation in exercise a) (to verify that this is correct you can either compare with eq. 5 or the line before g is defined ).