### PR TITLE
Fix typo for a_ho

### DIFF
--- a/doc/src/Projects/2022/Project1/Project1.do.txt
+++ b/doc/src/Projects/2022/Project1/Project1.do.txt
@@ -17,13 +17,13 @@ DATE: today
 
  A key feature of the trapped alkali and atomic hydrogen systems is that they are
  dilute. The characteristic dimensions of a typical trap for $^{87}$Rb is
- $a_{h0}=\left( {\hbar}/{m\omega_\perp}\right)^\frac{1}{2}=1-2 \times 10^4$
+ $a_{ho}=\left( {\hbar}/{m\omega_\perp}\right)^\frac{1}{2}=1-2 \times 10^4$
  \AA\ . The interaction between $^{87}$Rb atoms can be well represented
  by its s-wave scattering length, $a_{Rb}$. This scattering length lies in the
  range $85 a_0 < a_{Rb} < 140 a_0$ where $a_0 = 0.5292$ \AA\ is the Bohr radius.
  The definite value $a_{Rb} = 100 a_0$ is usually selected and
  for calculations the definite ratio of atom size to trap size 
- $a_{Rb}/a_{h0} = 4.33 \times 10^{-3}$ 
+ $a_{Rb}/a_{ho} = 4.33 \times 10^{-3}$ 
  is usually chosen. A typical $^{87}$Rb atom
  density in the trap is $n \simeq 10^{12}- 10^{14}$ atoms per cubic cm, giving an
  inter-atom spacing $\ell \simeq 10^4$ \AA. Thus the effective atom size is small


### PR DESCRIPTION
Should the characteristic dimension for the harmonic oscillator be a_{ho} with an "o" and not a "0"?